### PR TITLE
Add support for system-installed MKL libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ description = "Set up Intel oneAPI Math Kernel Library (oneMKL)"
 
 [build-dependencies]
 ureq = "3"
+intel-mkl-tool = { version = "0.8", optional = true }
 
 [features]
 default = ["ilp64", "sequential"]
@@ -21,3 +22,4 @@ lp64 = []
 ilp64 = []
 openmp = []
 sequential = []
+system = ["dep:intel-mkl-tool"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ You can control the integer size and threading model via Cargo features:
 - `lp64` — use the 32-bit integer interface.
 - `openmp` — use the Intel OpenMP runtime.
 - `sequential` — use sequential (single-threaded) execution.
+- `system` - use locally installed MKL libraries on your system instead of downloading and installing new ones.
 
 Default features are: `ilp64` and `sequential`.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,5 @@
 //
 // http://opensource.org/licenses/mit-license.php
 
+#![doc = include_str!("../README.md")]
 #![no_std]


### PR DESCRIPTION
Introduced a new `system` feature to enable the use of locally installed MKL libraries. Updated `build.rs` to handle configuration and metadata for the `system` feature. Adjusted `Cargo.toml` dependencies and feature configurations. Enhanced documentation with updated README and library-level documentation.